### PR TITLE
CS-210 - deploy Cert Services 2.4.0 app to new iamtools servers

### DIFF
--- a/ansible/install-app.yml
+++ b/ansible/install-app.yml
@@ -10,6 +10,7 @@
 
   vars:
     cs_root: /data/local/cs
+    proj_root: ..
 
   tasks:
 
@@ -24,7 +25,7 @@
   # change restarts tomcat
   - name: copy properties file
     copy:
-      src: ../cs.properties.{{ cluster_type }}
+      src: "{{ proj_root }}/cs.properties.{{ cluster_type }}"
       dest: "{{ cs_root }}/cs.properties"
       group: iam-dev
       mode: 0664
@@ -49,15 +50,22 @@
     notify: restart apache
     
   # update the cs.war file
-  - name: copy war
+  - name: copy cs.war
     copy: 
-      src: ../target/cs.war
-      dest: /data/webapps/cs.war
+      src: "{{ proj_root }}/target/cs.war"
+      dest: /tmp/cs.war
       group: iam-dev
       mode: 0664
-    notify: restart tomcat
+    register: warfile
 
-  # run any handlers 
+    # unpack the cs.war file
+  - name: unpack cs.war
+    shell: "rm -rf /data/webapps/cs; mkdir /data/webapps/cs; cd /data/webapps/cs; jar xf /tmp/cs.war"
+    when: warfile.changed
+    notify:
+      - restart tomcat
+
+    # run any handlers 
   - meta: flush_handlers
 
   handlers:

--- a/util/README.password
+++ b/util/README.password
@@ -1,12 +1,12 @@
-Instructions to change the passowrd for the incommon certificate service.
+Instructions to change the password for the InCommon certificate service.
 
 Comodo (InCommon) passwords expire every few months.  Changing them bimonthly works.
 
 
 You have to update the comodo.pw file on all certservice hosts:
 
-  iamtools11, iamtools12
-  iamtools-test01, iamtools-test02
+  iamtools21, iamtools22
+  iamtools-test11
 
 
 The password is in:  /data/local/etc/comodo.pw
@@ -15,7 +15,7 @@ The password is in:  /data/local/etc/comodo.pw
 
    (remember somewhere the old password)
 
-   [ I try to do this at the same time on both iamtools11 and iamtools12.
+   [ I try to do this at the same time on both iamtools21 and iamtools22.
      The others you can delay. ] 
 
 2) log in to the manager


### PR DESCRIPTION
Will probably noodle around a little to get rid of the warning ansible gives re: running 'rm', but this seems to work.