### PR TITLE
Add backups to Ansible scripts

### DIFF
--- a/ansible/install-app.yml
+++ b/ansible/install-app.yml
@@ -60,12 +60,12 @@
       group: iam-dev
       mode: 0664
       backup: true
-    register: warfile
 
     # unpack the cs.war file
   - name: unpack cs.war
-    shell: "rm -rf /data/webapps/cs; mkdir /data/webapps/cs; cd /data/webapps/cs; jar xf /data/local/wars/cs.war"
-    when: warfile.changed
+    # When unzipping, use -DD to update the last modified time of each extracted file
+    # Otherwise, the browser cache will not pick up the new version of the file!
+    shell: "rm -rf /data/webapps/cs; mkdir /data/webapps/cs; cd /data/webapps/cs; unzip -DD /data/local/wars/cs.war"
     notify:
       - restart tomcat
 

--- a/ansible/install-app.yml
+++ b/ansible/install-app.yml
@@ -29,6 +29,7 @@
       dest: "{{ cs_root }}/cs.properties"
       group: iam-dev
       mode: 0664
+      backup: true
     notify: restart tomcat
 
   # update http and https config
@@ -39,6 +40,7 @@
       dest: /data/conf/apache.conf.d/http.cs
       group: iam-dev
       mode: 0664
+      backup: true
     notify: restart apache
 
   - name: copy https apache config
@@ -47,6 +49,7 @@
       dest: /data/conf/apache.conf.d/https.cs
       group: iam-dev
       mode: 0664
+      backup: true
     notify: restart apache
 
   # update the cs.war file
@@ -56,6 +59,7 @@
       dest: /data/local/wars/cs.war
       group: iam-dev
       mode: 0664
+      backup: true
     register: warfile
 
     # unpack the cs.war file

--- a/ansible/install-app.yml
+++ b/ansible/install-app.yml
@@ -17,10 +17,10 @@
   - name: check for secrets file
     stat: path="{{ cs_root }}/cs-secrets.properties"
     register: cssecrets
-  - name: fail if secrets file not found 
+  - name: fail if secrets file not found
     fail: msg="secrets file not preloaded on target"
     when: not cssecrets.stat.exists
-      
+
   # copy cs properties file
   # change restarts tomcat
   - name: copy properties file
@@ -48,10 +48,10 @@
       group: iam-dev
       mode: 0664
     notify: restart apache
-    
+
   # update the cs.war file
   - name: copy cs.war
-    copy: 
+    copy:
       src: "{{ proj_root }}/target/cs.war"
       dest: /data/local/wars/cs.war
       group: iam-dev
@@ -65,7 +65,7 @@
     notify:
       - restart tomcat
 
-    # run any handlers 
+    # run any handlers
   - meta: flush_handlers
 
   handlers:
@@ -84,6 +84,3 @@
     shell: "c=0;while [ $c -lt 20 ]; do [[ \"`curl -k -f https://localhost/tomcatmanager/text/list 2>/dev/null  | grep 'cs'`\" =~ 'cs' ]] && exit 0; let c=c+1;sleep 5; done; exit 1"
     register: wait_result
     failed_when: "wait_result.rc != 0"
-
-
-

--- a/src/main/java/edu/washington/iam/ws/cabroker/util/PEMHelper.java
+++ b/src/main/java/edu/washington/iam/ws/cabroker/util/PEMHelper.java
@@ -111,7 +111,7 @@ public final class PEMHelper {
 
     } catch (Exception e) {
       log.debug("request DN parse exception: " + e);
-      throw new CBParseException("e.getMessage()");
+      throw new CBParseException(e.getMessage());
     }
     // see if we've got alt names (in extensions)
 
@@ -136,7 +136,7 @@ public final class PEMHelper {
         }
       } catch (Exception e) {
         log.debug("ignoring request ATTR parse exception: " + e);
-        // throw new CBParseException("e.getMessage()");
+        // throw new CBParseException(e.getMessage());
       }
     }
 
@@ -154,7 +154,7 @@ public final class PEMHelper {
 
     } catch (Exception e) {
       log.debug("request KEY parse exception: " + e);
-      throw new CBParseException("e.getMessage()");
+      throw new CBParseException(e.getMessage());
     }
     return 1;
   }


### PR DESCRIPTION
Makes sure the ansible scripts always back up any files that are changed.

I also fixed an issue that broke the server due to invalid timestamps on the browser cache. 

(The commits are organized to make it easy to review commit-by-commit)