### PR TITLE
Db migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.4.1</version>
+      <version>42.4.4</version>
     </dependency>
     <dependency>
       <groupId>com.mchange</groupId>
@@ -48,37 +48,37 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>5.3.22</version>
+      <version>5.3.33</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context-support</artifactId>
-      <version>5.3.22</version>
+      <version>5.3.33</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>5.3.22</version>
+      <version>5.3.33</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>5.3.22</version>
+      <version>5.3.33</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
-      <version>5.3.22</version>
+      <version>5.3.33</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
-      <version>5.3.22</version>
+      <version>5.3.33</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
-      <version>5.3.22</version>
+      <version>5.3.33</version>
     </dependency>
 
     <dependency>
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.71</version>
+      <version>1.74</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15on -->
     <dependency>
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.11</version>
+      <version>1.2.13</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>postgresql</artifactId>
       <version>42.4.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.mchange</groupId>
+      <artifactId>c3p0</artifactId>
+      <version>0.10.0</version>
+    </dependency>
 
 
     <dependency>

--- a/src/main/java/edu/washington/iam/ws/cabroker/registry/CBRegistry.java
+++ b/src/main/java/edu/washington/iam/ws/cabroker/registry/CBRegistry.java
@@ -30,7 +30,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Vector;
 import org.postgresql.jdbc3.Jdbc3PoolingDataSource;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +39,7 @@ public class CBRegistry {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  private DriverManagerDataSource dataSource;
+  private Jdbc3PoolingDataSource dataSource;
   private String serverName = "localhost";
   private String databaseName = "cbregistry";
   private String user;
@@ -565,7 +564,7 @@ public class CBRegistry {
     password = v;
   }
 
-  public void setDataSource(DriverManagerDataSource dataSource) {
+  public void setDataSource(Jdbc3PoolingDataSource dataSource) {
     this.dataSource = dataSource;
   }
 

--- a/src/main/java/edu/washington/iam/ws/cabroker/registry/CBRegistry.java
+++ b/src/main/java/edu/washington/iam/ws/cabroker/registry/CBRegistry.java
@@ -29,7 +29,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Vector;
-import org.postgresql.jdbc3.Jdbc3PoolingDataSource;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +39,7 @@ public class CBRegistry {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  private Jdbc3PoolingDataSource dataSource;
+  private DataSource dataSource;
   private String serverName = "localhost";
   private String databaseName = "cbregistry";
   private String user;
@@ -564,7 +564,7 @@ public class CBRegistry {
     password = v;
   }
 
-  public void setDataSource(Jdbc3PoolingDataSource dataSource) {
+  public void setDataSource(DataSource dataSource) {
     this.dataSource = dataSource;
   }
 

--- a/src/main/java/edu/washington/iam/ws/cabroker/registry/CBRegistry.java
+++ b/src/main/java/edu/washington/iam/ws/cabroker/registry/CBRegistry.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Vector;
 import org.postgresql.jdbc3.Jdbc3PoolingDataSource;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public class CBRegistry {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  private Jdbc3PoolingDataSource dataSource;
+  private DriverManagerDataSource dataSource;
   private String serverName = "localhost";
   private String databaseName = "cbregistry";
   private String user;
@@ -564,16 +565,13 @@ public class CBRegistry {
     password = v;
   }
 
+  public void setDataSource(DriverManagerDataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
   /* init */
   public void init() {
-    dataSource = new Jdbc3PoolingDataSource();
-    dataSource.setDataSourceName("CB source");
-    dataSource.setServerName(serverName);
-    dataSource.setDatabaseName(databaseName);
-    dataSource.setUser(user);
-    dataSource.setPassword(password);
-    dataSource.setMaxConnections(10);
-    log.debug("datasource initialized");
+    // No operations. The data source is now configured and set via Spring configuration.
   }
 
   public void cleanup() {}

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -45,7 +45,7 @@
     <bean id="csDataSource"
           class="org.springframework.jdbc.datasource.DriverManagerDataSource">
         <property name="driverClassName" value="org.postgresql.Driver"/>
-        <property name="url" value="jdbc:postgresql://${cs.db.url}"/>
+        <property name="url" value="jdbc:postgresql://${cs.db.host}.${cs.db.name}"/>
         <property name="username" value="${cs.db.username}"/>
         <property name="password" value="${cs.db.password}"/>
         <property name="connectionProperties">

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -42,11 +42,24 @@
         <property name="refreshInterval" value="1800" />
     </bean>
 
+    <bean id="csDataSource"
+          class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+        <property name="driverClassName" value="org.postgresql.Driver"/>
+        <property name="url" value="jdbc:postgresql://${cs.db.url}"/>
+        <property name="username" value="${cs.db.username}"/>
+        <property name="password" value="${cs.db.password}"/>
+        <property name="connectionProperties">
+            <props>
+                <prop key="sslrootcert">${cs.db.sslrootcert}</prop>
+                <prop key="sslcert">${cs.db.sslcert}</prop>
+                <prop key="sslkey">${cs.db.sslkey}</prop>
+                <prop key="sslpassword">${cs.db.sslpassword}</prop>
+            </props>
+        </property>
+    </bean>
+
     <bean id="cbRegistry" init-method="init" class="edu.washington.iam.ws.cabroker.registry.CBRegistry">
-        <property name="serverName" value="${cs.db.host}" />
-        <property name="databaseName" value="${cs.db.name}" />
-        <property name="user" value="${cs.db.user}" />
-        <property name="password" value="${cs.db.password}" />
+        <property name="dataSource" ref="csDataSource" />
     </bean>
 
 

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -42,16 +42,12 @@
         <property name="refreshInterval" value="1800" />
     </bean>
 
-    <bean id="csDataSource" class="org.postgresql.jdbc3.Jdbc3PoolingDataSource">
-        <property name="serverName" value="${cs.db.host}" />
-        <property name="databaseName" value="${cs.db.name}" />
-        <property name="user" value="${cs.db.username}" />
-        <property name="password" value="${cs.db.password}" />
-        <property name="sslMode" value="verify-ca" />
-        <property name="sslRootCert" value="${cs.db.sslrootcert}" />
-        <property name="sslCert" value="${cs.db.sslcert}" />
-        <property name="sslKey" value="${cs.db.sslkey}" />
-        <property name="sslPassword" value="${cs.db.sslpassword}" />
+    <bean id="csDataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource">
+        <property name="driverClass" value="org.postgresql.Driver"/>
+        <property name="jdbcUrl" value="jdbc:postgresql://${cs.db.host}/${cs.db.name}?sslmode=verify-ca&amp;sslrootcert=${cs.db.sslrootcert}&amp;sslcert=${cs.db.sslcert}&amp;sslkey=${cs.db.sslkey}"/>
+        <property name="user" value="${cs.db.username}"/>
+        <property name="password" value="${cs.db.password}"/>
+        <property name="testConnectionOnCheckout" value="true"/>
     </bean>
 
     <bean id="cbRegistry" init-method="init" class="edu.washington.iam.ws.cabroker.registry.CBRegistry">

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -42,20 +42,17 @@
         <property name="refreshInterval" value="1800" />
     </bean>
 
-    <bean id="csDataSource"
-          class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-        <property name="driverClassName" value="org.postgresql.Driver"/>
-        <property name="url" value="jdbc:postgresql://${cs.db.host}.${cs.db.name}"/>
-        <property name="username" value="${cs.db.username}"/>
-        <property name="password" value="${cs.db.password}"/>
-        <property name="connectionProperties">
-            <props>
-                <prop key="sslrootcert">${cs.db.sslrootcert}</prop>
-                <prop key="sslcert">${cs.db.sslcert}</prop>
-                <prop key="sslkey">${cs.db.sslkey}</prop>
-                <prop key="sslpassword">${cs.db.sslpassword}</prop>
-            </props>
-        </property>
+    <bean id="csDataSource" class="org.postgresql.jdbc3.Jdbc3PoolingDataSource">
+        <property name="serverName" value="${cs.db.host}" />
+        <property name="databaseName" value="${cs.db.name}" />
+        <property name="user" value="${cs.db.username}" />
+        <property name="password" value="${cs.db.password}" />
+        <property name="sslMode" value="verify-ca" />
+        <property name="sslRootCert" value="${cs.db.sslrootcert}" />
+        <property name="sslCert" value="${cs.db.sslcert}" />
+        <property name="sslKey" value="${cs.db.sslkey}" />
+        <property name="sslPassword" value="${cs.db.sslpassword}" />
+        <property name="sslfactory" value="org.postgresql.ssl.NonValidatingFactory" />
     </bean>
 
     <bean id="cbRegistry" init-method="init" class="edu.washington.iam.ws.cabroker.registry.CBRegistry">

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -52,7 +52,6 @@
         <property name="sslCert" value="${cs.db.sslcert}" />
         <property name="sslKey" value="${cs.db.sslkey}" />
         <property name="sslPassword" value="${cs.db.sslpassword}" />
-        <property name="sslfactory" value="org.postgresql.ssl.NonValidatingFactory" />
     </bean>
 
     <bean id="cbRegistry" init-method="init" class="edu.washington.iam.ws.cabroker.registry.CBRegistry">


### PR DESCRIPTION
Changes to support the migration to a GCP database.
1. Modified the application context to use a new connection pool and include the SSL connection parameters. All connection configuration is now in the context file.
2. Modified the one class that uses the database connection object. Removed configuration parameters and changed the object type to a generic DataSource type.
3. Updated pom.xml with some minor library version updates per recommendation from Dependabot.
