### PR TITLE
Updated the version number.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>edu.washington.iam</groupId>
   <artifactId>certservice</artifactId>
   <packaging>war</packaging>
-  <version>2.4.4</version>
+  <version>2.4.6</version>
   <name>Certificate Service Webapp</name>
 
   <repositories>


### PR DESCRIPTION
Updated the version number in the pom.xml file. The minor version is jumping by two because a previous update did not update the version number.
