### PR TITLE
Fix the cert warn job

### DIFF
--- a/cs.properties.tmpl
+++ b/cs.properties.tmpl
@@ -13,7 +13,7 @@ cs.root=/data/local/cs
 # database parameters
 cs.db.host=iamdbdev11.cac.washington.edu
 cs.db.name=certservice
-cs.db.user=cs
+cs.db.username=cs
 cs.db.password=some_password
 
 # remote ca parameters

--- a/util/settings.py
+++ b/util/settings.py
@@ -19,7 +19,7 @@ def init(props, secrets):
     cp = configparser.RawConfigParser()
     cp.read_file(pfp)
     db_access = 'host=%s dbname=%s user=%s password=%s' % \
-                (cp.get('base', 'cs.db.host'), cp.get('base', 'cs.db.name'), cp.get('base', 'cs.db.user'),
+                (cp.get('base', 'cs.db.host'), cp.get('base', 'cs.db.name'), cp.get('base', 'cs.db.username'),
                  cp.get('secrets', 'cs.db.password'))
     http_cert_file = cp.get('base', 'cs.webclient.certFile')
     http_key_file = cp.get('base', 'cs.webclient.keyFile')

--- a/util/settings.py
+++ b/util/settings.py
@@ -18,9 +18,11 @@ def init(props, secrets):
     pfp = io.StringIO('[base]\n' + open(props, 'r').read() + '\n[secrets]\n' + open(secrets, 'r').read())
     cp = configparser.RawConfigParser()
     cp.read_file(pfp)
-    db_access = 'host=%s dbname=%s user=%s password=%s' % \
+    ssl_key = cp.get('base', 'cs.db.sslkey').replace('.raw', '')
+    db_access = 'host=%s dbname=%s user=%s password=%s sslkey=%s sslcert=%s sslrootcert=%s sslmode=require' % \
                 (cp.get('base', 'cs.db.host'), cp.get('base', 'cs.db.name'), cp.get('base', 'cs.db.username'),
-                 cp.get('secrets', 'cs.db.password'))
+                 cp.get('secrets', 'cs.db.password'), ssl_key, cp.get('base', 'cs.db.sslcert'),
+                 cp.get('base', 'cs.db.sslrootcert'))
     http_cert_file = cp.get('base', 'cs.webclient.certFile')
     http_key_file = cp.get('base', 'cs.webclient.keyFile')
     gws_url_template = cp.get('base', 'cs.gws.urltemplate')


### PR DESCRIPTION
This job sends out the warnings when certificates are going to expire. It hasn't run in a while due to the database move. This PR updates the connection string to account for the new DB parameters.

Tested: Script runs successfully outside of the cron job on iam-tools21.

We ideally want to submit this soon, because it looks like this job doesn't queue things up when it fails to run. Instead, it only sends emails for certs that are _exactly_ 30 days away from expiry.